### PR TITLE
Updated rollback functionality to not remote embargo/expiry

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -1,0 +1,6 @@
+---
+Name: embargoexpirymodel
+---
+SilverStripe\ORM\DataObject:
+  allow_embargoed_editing: true
+  enforce_sequential_dates: false

--- a/src/Job/PublishTargetJob.php
+++ b/src/Job/PublishTargetJob.php
@@ -4,6 +4,7 @@ namespace Terraformers\EmbargoExpiry\Job;
 
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
 use SuperClosure\SerializableClosure;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Terraformers\EmbargoExpiry\Extension\EmbargoExpiryExtension;
@@ -78,7 +79,7 @@ class PublishTargetJob extends AbstractQueuedJob
 
     public function process()
     {
-        /** @var SiteTree $target */
+        /** @var DataObject|Versioned|EmbargoExpiryExtension $target */
         $target = $this->getTarget();
         $type = array_key_exists('type', $this->options) ? $this->options['type'] : null;
 
@@ -100,13 +101,11 @@ class PublishTargetJob extends AbstractQueuedJob
             $target->prePublishTargetJob($this->options);
             $target->unlinkPublishJobAndDate();
             $target->writeWithoutVersion();
-            $target->updateVersionsTableRecord(EmbargoExpiryExtension::JOB_TYPE_PUBLISH);
             $target->publishRecursive();
         } elseif ($type === EmbargoExpiryExtension::JOB_TYPE_UNPUBLISH) {
             $target->preUnPublishTargetJob($this->options);
             $target->unlinkUnPublishJobAndDate();
             $target->writeWithoutVersion();
-            $target->updateVersionsTableRecord(EmbargoExpiryExtension::JOB_TYPE_UNPUBLISH);
             $target->doUnpublish();
         }
 


### PR DESCRIPTION
After some discussion it was decided that we should not dictate that an Embargo/Expiry date on old versions should be removed on rollback. We have instead updated the status message to be a "warning", with appropriate messages:
<img width="499" alt="screen shot 2018-07-23 at 7 41 59 am" src="https://user-images.githubusercontent.com/505788/43049884-77264c5e-8e53-11e8-9042-0d70871089ec.png">

This message will show up in the History tab as authors browse through versions.

**Importantly, this behaviour also matches the behaviour found in the SilverStripe 4 version of the Advanced Workflow module.**

Developers should be free to add their own rollback behaviour to determine whether or not these dates are removed. Though, I do have an open issue on Versioned questioning if there is an appropriate place to implement this sort of behaviour:
https://github.com/silverstripe/silverstripe-versioned/issues/170