### PR TITLE
Allow Fallback to SiteTree Permissions

### DIFF
--- a/src/Extension/EmbargoExpiryExtension.php
+++ b/src/Extension/EmbargoExpiryExtension.php
@@ -554,8 +554,10 @@ class EmbargoExpiryExtension extends DataExtension implements PermissionProvider
             return true;
         }
 
+        // If the owner object allows embargoed editing, then return null so
+        // we can fall back to SiteTree behaviours (SiteTree and inherited permissions)
         if ($this->owner->config()->get('allow_embargoed_editing')) {
-            return true;
+            return null;
         }
 
         if ($this->owner->getIsPublishScheduled()) {

--- a/src/Extension/EmbargoExpiryExtension.php
+++ b/src/Extension/EmbargoExpiryExtension.php
@@ -554,8 +554,8 @@ class EmbargoExpiryExtension extends DataExtension implements PermissionProvider
             return true;
         }
 
-        // If the owner object allows embargoed editing, then return null so
-        // we can fall back to SiteTree behaviours (SiteTree and inherited permissions)
+        // If the owner object allows embargoed editing, then return null so we can fall back to SiteTree behaviours
+        // (SiteTree and inherited permissions)
         if ($this->owner->config()->get('allow_embargoed_editing')) {
             return null;
         }
@@ -569,7 +569,8 @@ class EmbargoExpiryExtension extends DataExtension implements PermissionProvider
             return false;
         }
 
-        return true;
+        // Everything looks ok, so let's fall back to SiteTree behaviours (SiteTree and inherited permissions).
+        return null;
     }
 
     /**

--- a/tests/php/Extension/EmbargoExpiryExtensionTest.php
+++ b/tests/php/Extension/EmbargoExpiryExtensionTest.php
@@ -79,7 +79,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
 
         $page->write();
 
-        $this->assertTrue($page->isEditable());
+        $this->assertNull($page->isEditable());
     }
 
     /**
@@ -94,7 +94,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page->DesiredPublishDate = '2014-02-05 12:00:00';
         $page->write();
 
-        $this->assertTrue($page->isEditable());
+        $this->assertNull($page->isEditable());
     }
 
     /**

--- a/tests/php/Extension/EmbargoExpiryExtensionTest.php
+++ b/tests/php/Extension/EmbargoExpiryExtensionTest.php
@@ -87,14 +87,31 @@ class EmbargoExpiryExtensionTest extends SapphireTest
      */
     public function testIsEditableWithEmbargo()
     {
+        Config::modify()->set(SiteTree::class, 'allow_embargoed_editing', true);
+
         /** @var SiteTree|EmbargoExpiryExtension $page */
         $page = $this->objFromFixture(SiteTree::class, 'home');
-        $page->config()->set('allow_embargoed_editing', true);
 
         $page->DesiredPublishDate = '2014-02-05 12:00:00';
         $page->write();
 
         $this->assertNull($page->isEditable());
+    }
+
+    /**
+     * @throws \SilverStripe\ORM\ValidationException
+     */
+    public function testIsNotEditableWithEmbargo()
+    {
+        Config::modify()->set(SiteTree::class, 'allow_embargoed_editing', false);
+
+        /** @var SiteTree|EmbargoExpiryExtension $page */
+        $page = $this->objFromFixture(SiteTree::class, 'home');
+
+        $page->DesiredPublishDate = '2014-02-05 12:00:00';
+        $page->write();
+
+        $this->assertFalse($page->isEditable());
     }
 
     /**


### PR DESCRIPTION
If your site has a SiteTree extension extending canEdit and returning true then the default SiteTree Permissions are never called, and the user is always granted permission.

Instead, return null, or "Don't affect the outcome" and rely on SiteTree or Inherited permissions

@see https://github.com/silverstripe-terraformers/silverstripe-embargo-expiry/issues/34

Resolves #34 