### PR TITLE
MISC: Reduce EmbargoExpiryExtension complexity. Rename some methods to be more descriptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,6 @@
 # Change Log
 
-## [1.0.1](https://github.com/silverstripe-terraformers/silverstripe-embargo-expiry/releases/1.0.1) (13 March 2019)
-
- * Reduce complexity of EmbargoExpiryExtension methods.
- * Added test coverage for EmbargoExpiryFluentExtension.
- * Update linting and tests for Extensions.
- * Updated doc blocks and conditional statements in Jobs.
- * Update user docs.
- * Added .gitattributes.
- * Add license/contribution/changelog/etc docs.
- * Scrutinizer fixes.
-
-## [1.0.0](https://github.com/silverstripe-terraformers/silverstripe-embargo-expiry/releases/1.0.0) (12 March 2019)
+## [1.0.0](https://github.com/silverstripe-terraformers/silverstripe-embargo-expiry/releases/1.0.0) (13 March 2019)
 
 ### NON BACKWARDS COMPATIBLE CHANGE
 
@@ -28,17 +17,30 @@ RemoveEmbargoExpiry
 
 When you upgrade to `1.0.0`, if you have user groups other than just `ADMIN`, you will need to update those user groups to have these new permissions.
 
+## NON BACKWARDS COMPATIBLE CHANGE - METHOD NAME CHANGES
+
+`EmbargoExpiryExtension`:
+`addEmbargoExpiryNoticeFields` is now `addNoticeOrWarningFields`.
+`addPublishingScheduleFields` is now `addDesiredDateFields`.
+`addPublishingScheduleMessageFields` is now `addScheduledDateFields`.
+
 ### Bugfix
 
 **Publish** button was not being removed when the page was reloaded with an existing `PublishOnDate`.
 
 ### Change
 
-Improved readability of JS.
-
-Renamed `config.yml` to `extensions.yml` and added the `CMSMain` extension by default.
-
-Updated README.
+ * Reduce complexity of EmbargoExpiryExtension methods.
+ * Added test coverage for EmbargoExpiryFluentExtension.
+ * Update linting and tests for Extensions.
+ * Updated doc blocks and conditional statements in Jobs.
+ * Update user docs.
+ * Added .gitattributes.
+ * Add license/contribution/changelog/etc docs.
+ * Scrutinizer fixes.
+ * Improved readability of JS.
+ * Renamed `config.yml` to `extensions.yml` and added the `CMSMain` extension by default.
+ * Updated README.
 
 ## [v1.0.0 Release Candidate 4](https://github.com/silverstripe-terraformers/silverstripe-embargo-expiry/releases/v1.0.0-rc4) (15 Feb 2019)
 

--- a/tests/php/Extension/EmbargoExpiryExtensionTest.php
+++ b/tests/php/Extension/EmbargoExpiryExtensionTest.php
@@ -222,7 +222,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'messages1');
         $fields = new FieldList();
 
-        $page->addEmbargoExpiryNoticeFields($fields);
+        $page->addNoticeOrWarningFields($fields);
 
         $fieldsArray = $fields->toArray();
 
@@ -247,7 +247,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'messages1');
         $fields = new FieldList();
 
-        $page->addEmbargoExpiryNoticeFields($fields);
+        $page->addNoticeOrWarningFields($fields);
 
         $fieldsArray = $fields->toArray();
 
@@ -273,7 +273,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'messages1');
         $fields = new FieldList();
 
-        $page->addEmbargoExpiryNoticeFields($fields);
+        $page->addNoticeOrWarningFields($fields);
 
         $fieldsArray = $fields->toArray();
 
@@ -299,7 +299,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'messages1');
         $fields = new FieldList();
 
-        $page->addEmbargoExpiryNoticeFields($fields);
+        $page->addNoticeOrWarningFields($fields);
 
         $fieldsArray = $fields->toArray();
 
@@ -354,7 +354,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $this->assertContains('Please contact an administrator', $message);
     }
 
-    public function testAddPublishingScheduleFieldsWithoutPermission(): void
+    public function testAddDesiredDateFieldsWithoutPermission(): void
     {
         Config::modify()->set(SiteTree::class, 'allow_embargoed_editing', false);
 
@@ -364,7 +364,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'fields1');
         $fields = new FieldList([TabSet::create('Root')]);
 
-        $page->addPublishingScheduleFields($fields);
+        $page->addDesiredDateFields($fields);
 
         $publishField = $fields->dataFieldByName('DesiredPublishDate');
         $unPublishField = $fields->dataFieldByName('DesiredUnPublishDate');
@@ -372,12 +372,26 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $this->assertNotNull($publishField);
         $this->assertTrue($publishField->isReadonly());
         $this->assertNotNull($unPublishField);
-        $this->assertTrue($unPublishField->isReadonly());
+        $this->assertTrue($unPublishField->isReadonly());;
+    }
+
+    public function testAddScheduledDateFieldsWithoutPermission(): void
+    {
+        Config::modify()->set(SiteTree::class, 'allow_embargoed_editing', false);
+
+        $this->logOut();
+
+        /** @var SiteTree|EmbargoExpiryExtension $page */
+        $page = $this->objFromFixture(SiteTree::class, 'fields1');
+        $fields = new FieldList([TabSet::create('Root')]);
+
+        $page->addScheduledDateFields($fields);
+
         $this->assertNotNull($fields->dataFieldByName('PublishOnDate'));
         $this->assertNotNull($fields->dataFieldByName('UnPublishOnDate'));
     }
 
-    public function testAddPublishingScheduleFieldsWithPermission(): void
+    public function testAddDesiredDateFieldsWithPermission(): void
     {
         Config::modify()->set(SiteTree::class, 'allow_embargoed_editing', false);
 
@@ -387,7 +401,7 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'fields1');
         $fields = new FieldList([TabSet::create('Root')]);
 
-        $page->addPublishingScheduleFields($fields);
+        $page->addDesiredDateFields($fields);
 
         $publishField = $fields->dataFieldByName('DesiredPublishDate');
         $unPublishField = $fields->dataFieldByName('DesiredUnPublishDate');
@@ -396,6 +410,20 @@ class EmbargoExpiryExtensionTest extends SapphireTest
         $this->assertFalse($publishField->isReadonly());
         $this->assertNotNull($unPublishField);
         $this->assertFalse($unPublishField->isReadonly());
+    }
+
+    public function testAddScheduledDateFieldsWithPermission(): void
+    {
+        Config::modify()->set(SiteTree::class, 'allow_embargoed_editing', false);
+
+        $this->logInWithPermission('ADMIN');
+
+        /** @var SiteTree|EmbargoExpiryExtension $page */
+        $page = $this->objFromFixture(SiteTree::class, 'fields1');
+        $fields = new FieldList([TabSet::create('Root')]);
+
+        $page->addScheduledDateFields($fields);
+
         $this->assertNotNull($fields->dataFieldByName('PublishOnDate'));
         $this->assertNotNull($fields->dataFieldByName('UnPublishOnDate'));
     }


### PR DESCRIPTION
## NON BACKWARDS COMPATIBLE CHANGE - METHOD NAME CHANGES

`EmbargoExpiryExtension`:
`addEmbargoExpiryNoticeFields` is now `addNoticeOrWarningFields`.
`addPublishingScheduleFields` is now `addDesiredDateFields`.
`addPublishingScheduleMessageFields` is now `addScheduledDateFields`.