### PR TITLE
MISC Bump workflow to 0.1.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.1
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.2
     with:
       run_phpcoverage: true


### PR DESCRIPTION
Codecov was temporarily commented out in 0.1.1 - I've released a new version with codecov enabled