### PR TITLE
Updating PHP 7.1 constraint to PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "issues": "https://github.com/silverstripe-terraformers/embargo-expiry/issues"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.1 || ^8.0",
     "silverstripe/vendor-plugin": "^1.0",
     "silverstripe/framework": "^4@dev",
     "silverstripe/cms": "^4@dev",


### PR DESCRIPTION
Because the master branch currently has PHP constraint of PHP `^7.1` whenever this module is used on PHP 8 builds the tagged `RC` versions are installed because they do not have a PHP version constraint. 

With a PHP 8.0 constraint this will enable composer to pick up the latest releases for PHP 8 builds.

> NB:  Checked the unit tests and looks like fluent has issues in PHP 8 so have not updated phpunit constraint.