### PR TITLE
ENH: Add retry for failed publish/unpublish race condition

### DIFF
--- a/src/Job/PublishTargetJob.php
+++ b/src/Job/PublishTargetJob.php
@@ -8,12 +8,14 @@ use SilverStripe\Versioned\Versioned;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Terraformers\EmbargoExpiry\Extension\EmbargoExpiryExtension;
 use Terraformers\EmbargoExpiry\Job\State\ActionProcessingState;
+use Terraformers\EmbargoExpiry\Job\Traits\RetryTrait;
 
 /**
  * @property array $options
  */
 class PublishTargetJob extends AbstractQueuedJob
 {
+    use RetryTrait;
 
     /**
      * @var DataObject
@@ -87,9 +89,11 @@ class PublishTargetJob extends AbstractQueuedJob
         $target->invokeWithExtensions('prePublishTargetJob', $options);
         $this->options = $options;
 
-        $target->unlinkPublishJobAndDate();
-        $target->writeWithoutVersion();
-        $target->publishRecursive();
+        $this->executeRetry($target, function (DataObject $target) {
+            $target->unlinkPublishJobAndDate();
+            $target->writeWithoutVersion();
+            $target->publishRecursive();
+        }, "Failed to publish after %d retries (DB contention)");
 
         // Make sure to use local variables for passing by reference as these are job properties
         // which are manipulated via magic methods and these do not work with passing by reference directly

--- a/src/Job/Traits/RetryTrait.php
+++ b/src/Job/Traits/RetryTrait.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Terraformers\EmbargoExpiry\Job\Traits;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
+
+trait RetryTrait
+{
+    use Configurable;
+
+    /**
+     * List of transient DB error messages to retry on
+     *
+     * @config
+     */
+    private static array $retryable_errors = [
+        'Duplicate entry',
+        'Deadlock found',
+        'Lock wait timeout exceeded',
+        'Serialization failure',
+        'try restarting transaction',
+    ];
+
+    /**
+     * Number of retries for transient DB errors before failing and re-queuing the job
+     *
+     * @config
+     */
+    private static int $retries = 3;
+
+    /**
+     * When re-queuing a job after exhausting retries, how many seconds to wait before next attempt.
+     *
+     * @config
+     */
+    private static int $next_job_time = 60;
+
+    /**
+     * Attempt to execute a callback with retry behaviour for transient DB errors.
+     *
+     * @param \SilverStripe\ORM\DataObject $target a DataObject context that will be provided to the callback.
+     * @param callable $callback the callable to execute. The callable will be invoked as `callback($target)`.
+     * @param string $message a fallback text to use when logging; note this value will be overwritten with
+     *                        the exception message when an exception occurs.
+     * @throws \SilverStripe\Core\Validation\ValidationException
+     * @throws \Throwable
+     */
+    private function executeRetry(DataObject $target, callable $callback, string $message): void
+    {
+        // Read configured values from the consuming class.
+        $callerClass = get_class($this);
+        $retryableErrors = $callerClass::config()->get('retryable_errors');
+        $retries = $callerClass::config()->get('retries');
+        $nextJobTime = $callerClass::config()->get('retries');
+
+        // No retry configuration, just execute the callback directly.
+        if (empty($retryableErrors) || $retries <= 0) {
+            $callback($target);
+            return;
+        }
+
+        $attempt = 0;
+        while ($attempt < $retries) {
+            try {
+                // Execute the provided callback, if successful we are done.
+                $callback($target);
+                return;
+            } catch (\Throwable $exception) {
+                // Capture the error message for retry detection and (later) logging.
+                $exceptionMessage = $exception->getMessage();
+
+                // Check if message matches any retryable pattern
+                $isRetryable = (bool)array_filter(
+                    $retryableErrors,
+                    fn($pattern) => stripos($exceptionMessage, $pattern) !== false
+                );
+
+                // Increment attempt counter and wait a short time before retrying.
+                if ($isRetryable) {
+                    $attempt++;
+                    usleep(300000 * $attempt);
+                    continue;
+                }
+
+                // If the error isn't considered retryable, rethrow immediately so callers can handle it.
+                throw $exception;
+            }
+        }
+
+        // If we exhausted our retries, re-queue the job for later processing, and log the failure.
+        $cloneJob = clone $this;
+        QueuedJobService::singleton()->queueJob(
+            $cloneJob,
+            DBDatetime::create()->setValue(DBDatetime::now()->getTimestamp() + $nextJobTime)->Rfc2822()
+        );
+        DB::alteration_message(sprintf($message, $retries));
+    }
+}

--- a/src/Job/UnPublishTargetJob.php
+++ b/src/Job/UnPublishTargetJob.php
@@ -8,12 +8,14 @@ use SilverStripe\Versioned\Versioned;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Terraformers\EmbargoExpiry\Extension\EmbargoExpiryExtension;
 use Terraformers\EmbargoExpiry\Job\State\ActionProcessingState;
+use Terraformers\EmbargoExpiry\Job\Traits\RetryTrait;
 
 /**
  * @property array|null $options
  */
 class UnPublishTargetJob extends AbstractQueuedJob
 {
+    use RetryTrait;
 
     /**
      * @var DataObject
@@ -90,9 +92,11 @@ class UnPublishTargetJob extends AbstractQueuedJob
         $target->invokeWithExtensions('preUnPublishTargetJob', $options);
         $this->options = $options;
 
-        $target->unlinkUnPublishJobAndDate();
-        $target->writeWithoutVersion();
-        $target->doUnpublish();
+        $this->executeRetry($target, function (DataObject $target) {
+            $target->unlinkUnPublishJobAndDate();
+            $target->writeWithoutVersion();
+            $target->doUnpublish();
+        }, "Failed to unpublish after %d retries (DB contention)");
 
         // Make sure to use local variables for passing by reference as these are job properties
         // which are manipulated via magic methods and these do not work with passing by reference directly

--- a/tests/Job/RetryTraitTest.php
+++ b/tests/Job/RetryTraitTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Terraformers\EmbargoExpiry\Tests\Job;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+use Terraformers\EmbargoExpiry\Job\PublishTargetJob;
+use Terraformers\EmbargoExpiry\Job\Traits\RetryTrait;
+use Terraformers\EmbargoExpiry\Job\UnPublishTargetJob;
+use Exception;
+
+class RetryTraitTest extends SapphireTest
+{
+
+    public function testConfiguration(): void
+    {
+        $this->assertEquals(3, PublishTargetJob::config()->get('retries'));
+        $this->assertEquals(60, PublishTargetJob::config()->get('next_job_time'));
+        $this->assertEquals(3, UnPublishTargetJob::config()->get('retries'));
+        $this->assertEquals(60, UnPublishTargetJob::config()->get('next_job_time'));
+
+
+        PublishTargetJob::config()->set('next_job_time', 120);
+        PublishTargetJob::config()->set('retries', 4);
+        UnPublishTargetJob::config()->set('next_job_time', 121);
+        UnPublishTargetJob::config()->set('retries', 5);
+
+        $this->assertEquals(120, PublishTargetJob::config()->get('next_job_time'));
+        $this->assertEquals(121, UnPublishTargetJob::config()->get('next_job_time'));
+        $this->assertEquals(5, UnPublishTargetJob::config()->get('retries'));
+    }
+
+    public function testRetry(): void
+    {
+        // Mock DataObject and job to test RetryTrait
+        $page = SiteTree::create();
+        $job = new class extends AbstractQueuedJob {
+            use RetryTrait;
+
+            public function testMethod($target, $callback, $message)
+            {
+                $this->executeRetry($target, $callback, $message);
+            }
+
+            public function getTitle()
+            {
+                return '';
+            }
+
+            public function process()
+            {
+            }
+        };
+
+        // Test no retries because retries is set to 0
+        $job->config()->set('retries', 0);
+        $job->config()->set('retryable_errors', [
+            'Deadlock found'
+        ]);
+
+        // Check that with 0 retries, the write function executes without retrying
+        $job->testMethod($page, function ($target) {
+            $target->setField('Counter', $target->getField('Counter') + 1);
+        }, 'Test message');
+        $this->assertEquals(1, $page->getField('Counter'));
+
+        // Test with 2 retries on 'Deadlock found' error
+        $job->config()->set('retries', 2);
+        $attempts = 0;
+        $job->testMethod($page, function ($target) use (&$attempts) {
+            $attempts++;
+            if ($attempts < 3) {
+                throw new \Exception('Deadlock found when trying to get lock; try restarting transaction');
+            }
+        }, 'Test  message');
+
+        // Check that the method was retried twice before succeeding
+        $this->assertEquals(2, $attempts);
+    }
+}


### PR DESCRIPTION
Jobs are failing with either 'Duplicate entry' errors in the version table or 'Deadlock found' errors.

This PR addresses these errors by retrying the content publishing. If the retry fails, it schedules another job to run a few minutes later.

Currently, when jobs fail, the content remains unpublished until a CMS user notices the issue.

These errors occur in the following scenarios:

Deadlocks: Multiple database connections each hold locks on certain rows while waiting for locks held by other connections, resulting in a circular dependency. MySQL throws the error 'Deadlock found'.

Duplicate version entries: Another database connection modifies the version number at the same time the job is attempting to publish the same version.
